### PR TITLE
Remove CMS_TEMPLATES shorthand ...

### DIFF
--- a/cms_templates/middleware.py
+++ b/cms_templates/middleware.py
@@ -17,7 +17,7 @@ from django.core.exceptions import PermissionDenied
 
 logger = logging.getLogger(__name__)
 
-CMS_TEMPLATES = settings.__class__.CMS_TEMPLATES = make_tls_property()
+settings.__class__.CMS_TEMPLATES = make_tls_property()
 CMS_TEMPLATE_INHERITANCE_TITLE = 'Inherit the template of the nearest ancestor'
 
 
@@ -105,9 +105,10 @@ class DBTemplatesMiddleware(object):
             logger.error('Current site not found: %d. '
                          'It was probably deleted' % site_id)
             raise Http404
-        settings.__class__.CMS_TEMPLATES.value = [(templ.name, templ.name) for templ in templates]
-        if not settings.__class__.CMS_TEMPLATES.value:
-            settings.__class__.CMS_TEMPLATES.value = [('dummy',
+        CMS_TEMPLATES = settings.__class__.CMS_TEMPLATES
+        CMS_TEMPLATES.value = [(templ.name, templ.name) for templ in templates]
+        if not CMS_TEMPLATES.value:
+            CMS_TEMPLATES.value = [('dummy',
                                     'Please create a template first.')]
 
         # This is a huge hack.
@@ -118,5 +119,5 @@ class DBTemplatesMiddleware(object):
             choices += [(settings.CMS_TEMPLATE_INHERITANCE_MAGIC,
                          CMS_TEMPLATE_INHERITANCE_TITLE)]
         Page._meta.get_field_by_name('template')[0].choices[:] = choices
-        settings.__class__.CMS_TEMPLATES.value.append((settings.CMS_TEMPLATE_INHERITANCE_MAGIC,
+        CMS_TEMPLATES.value.append((settings.CMS_TEMPLATE_INHERITANCE_MAGIC,
                                     CMS_TEMPLATE_INHERITANCE_TITLE))


### PR DESCRIPTION
...so it won't end up referencing to a different object when
tests asign to settings.**class**.CMS_TEMPLATES a different object.

Warning:
- a test in lunchbox/tests_admin.py that took advantage of the
  previous behaviour will fail unless LUN-1661 is integrated.

The problem
- The inital implementaion assumed settings.**class**.CMS_TEMPLATES
  would be initialized only once.
- DBTemplatesMiddleware uses the CMS_TEMPLATES shorthand for
  settings.**class**.CMS_TEMPLATES.
- When a test modifies settings.**class**.CMS_TEMPLATES, the
  CMS_TEMPLATES is NOT updated, it will reference the old object.
- When another test creates Template.objects.all() = [ stuff ], calls
  self.client.get('/admin/') it expects the middleware to put those
  templates in settings.**class**.CMS_TEMPLATES.value
- What actually happens is that the templates end up only in the
  CMS_TEMPLATES shorthand.
