### PR TITLE
LUN-1869: Since we are managing the state of the current site id, it is ...

### DIFF
--- a/cms_templates/middleware.py
+++ b/cms_templates/middleware.py
@@ -45,12 +45,12 @@ def _set_cms_templates_for_request(request):
     Thus this function makes sure CMS_TEMPLATES's value is correct
     with respect to the current request.
     '''
-    site_id = request.session.get('cms_admin_site', settings.SITE_ID)
     CMS_TEMPLATES = settings.__class__.CMS_TEMPLATES
     CMS_TEMPLATES.value = [('dummy', 'Please create a template first.'),
         (settings.CMS_TEMPLATE_INHERITANCE_MAGIC,
         CMS_TEMPLATE_INHERITANCE_TITLE)
     ]
+    site_id = request.session.get('cms_admin_site', settings.SITE_ID)
     try:
         templates = get_site_templates(site_id)
     except (Site.DoesNotExist, ValueError):


### PR DESCRIPTION
...important to sync the CMS_TEMPLATES variables as sooner as possible in the request/response cycle, so that even on early middleware chain breaking (caused by some exception), the error page will be displayed correctly with respect to the current site. This fix also ensures that we are able to show the CMS error page even if there is an early exception raised in the middleware chain
